### PR TITLE
Update support page

### DIFF
--- a/content/support/contents.lr
+++ b/content/support/contents.lr
@@ -7,17 +7,22 @@ body:
 Hello,
 if you have a problem with Unknown Horizons you are in the correct place to get help and solve your problem.
 
+The FIFE version of Unknown Horizons is no longer supported. You can try to ask help about crashes, but it is unlikely that we can do anything about it.
 
-![FAQ](/static/buttons/base_button_faq.png)Before continuing with further steps, please see if your problem is already answered in our [problem database (FAQ)](https://github.com/unknown-horizons/unknown-horizons/wiki/Problem-database)!
+We are working on a [Godot version](https://github.com/unknown-horizons/godot-port/), but this is not playable yet.
+
+<!-- ![FAQ](/static/buttons/base_button_faq.png)Before continuing with further steps, please see if your problem is already answered in our [problem database (FAQ)](https://github.com/unknown-horizons/unknown-horizons/wiki/Problem-database)! -_.
 
 
 If your problem is not answered in the problem database, you have a few options:
 
-![IRC](/static/buttons/base_button_irc.png)Get in contact with the team directly using our [IRC Chat](https://webchat.freenode.net/?channels=unknown-horizons) (also webbased).
+![Discord](/static/Discord-Logo-Color.png)Get in contact with the team directly using our [Discord Server](https://discord.gg/VX6m2ZX). This is the main method of contacting the team.
 
-![Discord](/static/Discord-Logo-Color.png)Get in contact with the team directly using our [Discord Server](https://discord.gg/VX6m2ZX)
+![IRC](/static/buttons/base_button_irc.png)Get in contact with the team directly using our [IRC Chat](https://webchat.freenode.net/?channels=unknown-horizons) (also webbased). Not all the team members are there. Remeber that it may take a while to see the question, so be prepared to wait a day or more.
 
-![Forum](/static/buttons/base_button_forums.png)Leave us a message on the [Forum](https://forum.unknown-horizons.org/), useful if no one is available on [IRC](https://webchat.freenode.net/?channels=unknown-horizons).
 
-![Bug Tracker](/static/buttons/base_button_bugs.png)Leave a bugreport on our [Bug Tracker at Github](http://bugs.unknown-horizons.org/).
+
+<!-- ![Forum](/static/buttons/base_button_forums.png)Leave us a message on the [Forum](https://forum.unknown-horizons.org/), useful if no one is available on [IRC](https://webchat.freenode.net/?channels=unknown-horizons). -->
+
+![Bug Tracker](/static/buttons/base_button_bugs.png)Leave a bugreport on our [Bug Tracker at Github](https://github.com/unknown-horizons/unknown-horizons/issues). Keep in mind that this version of Unknown Horizons is not supported anymore (we don' have developers for this) so we probably won't be able to fix it.
 


### PR DESCRIPTION
The support page was horribly outdated, redirecting people to the wrong locations.

I have left the old information in comments for now. Should I delete this completely?

It looked like the knowledge base had no information that's relevant for the latest version, so I thought it would be better to remove the link.