### PR TITLE
Fix Discord link

### DIFF
--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -37,7 +37,7 @@
       <div class="col-lg-4">
         <h2>Support</h2>
         <p>
-          Need help running <em>Unknown Horizons</em>? Read our <a href="https://github.com/unknown-horizons/unknown-horizons/wiki/FAQ">FAQ</a>, the most common questions are answered there. Need further help? Join us on <a href="https://discord.gg/VX6m2ZX/">Discord</a>.
+          Need help running <em>Unknown Horizons</em>? Read our <a href="https://github.com/unknown-horizons/unknown-horizons/wiki/FAQ">FAQ</a>, the most common questions are answered there. Need further help? Join us on <a href="https://discord.gg/VX6m2ZX">Discord</a>.
         </p>
         <a href="/support/">Read more</a>
       </div>


### PR DESCRIPTION
Discord channel link doesn't work with slash at the end. Fixed that.